### PR TITLE
Manage content statuses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     theblog (0.0.1.1)
+      aasm
       bootstrap-sass
       bootstrap-wysihtml5-rails
       haml (~> 4.0)
@@ -20,6 +21,7 @@ GEM
   remote: https://rubygems.org/
   remote: https://rails-assets.org/
   specs:
+    aasm (4.5.1)
     actionmailer (4.2.5)
       actionpack (= 4.2.5)
       actionview (= 4.2.5)
@@ -73,6 +75,7 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     coderay (1.1.0)
+    concurrent-ruby (1.0.0)
     devise (3.5.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -188,7 +191,7 @@ GEM
       rspec-mocks (~> 3.1.0)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.1)
-    sass (3.4.19)
+    sass (3.4.20)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.1)
@@ -210,7 +213,8 @@ GEM
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
     slop (3.6.0)
-    sprockets (3.4.1)
+    sprockets (3.5.2)
+      concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (2.3.3)
       actionpack (>= 3.0)
@@ -221,7 +225,7 @@ GEM
     tilt (2.0.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    warden (1.2.3)
+    warden (1.2.4)
       rack (>= 1.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)

--- a/app/controllers/theblog/admin/categories_controller.rb
+++ b/app/controllers/theblog/admin/categories_controller.rb
@@ -2,6 +2,6 @@ module Theblog
   class Admin::CategoriesController < Admin::ItemsController
     MODEL = Theblog::Category
     ATTRIBUTES = [:title, :slug, :description, :tags]
-    INDEX = [:title, :description]
+    INDEX = [:title, :description, :content_status]
   end
 end

--- a/app/controllers/theblog/admin/items_controller.rb
+++ b/app/controllers/theblog/admin/items_controller.rb
@@ -1,5 +1,8 @@
 module Theblog
   class Admin::ItemsController < AdminController
+
+    before_action :update_content_status, only: [:draft, :publish, :block, :unblock]
+
     def new
       @item = model.new
     end
@@ -24,8 +27,30 @@ module Theblog
       end
     end
 
+    def draft; end
+
+    def publish; end
+
+    def block; end
+
+    def unblock; end
+
+    private def update_content_status
+      state = params["action"]
+      authorize item, :"#{state}?"
+
+      item.send("#{state}!")
+      redirect_to :back, notice: "Item is #{state}ed"
+    rescue AASM::InvalidTransition => err
+      redirect_to :back, alert: "Item is not #{state}ed"
+    end
+
     private def item
-      @item ||= model.find(params[:id])
+      @item ||= if params.has_key?("#{model_params_key}_id")
+                  model.find(params["#{model_params_key}_id"])
+                else
+                  model.find(params[:id])
+                end
     end
     helper_method :item
 

--- a/app/controllers/theblog/admin/pages_controller.rb
+++ b/app/controllers/theblog/admin/pages_controller.rb
@@ -2,6 +2,6 @@ module Theblog
   class Admin::PagesController < Admin::ItemsController
     MODEL = Theblog::Page
     ATTRIBUTES = [:title, :slug, :description, {body: :wysihtml5}, :tags]
-    INDEX = [:title, :description, :body]
+    INDEX = [:title, :description, :body, :content_status]
   end
 end

--- a/app/controllers/theblog/admin/posts_controller.rb
+++ b/app/controllers/theblog/admin/posts_controller.rb
@@ -2,7 +2,7 @@ module Theblog
   class Admin::PostsController < Admin::ItemsController
     MODEL = Theblog::Post
     ATTRIBUTES = [:title, :slug, :description, {body: :wysihtml5}, :tags]
-    INDEX = [:title, :description, :body, :category]
+    INDEX = [:title, :description, :body, :category, :content_status]
     ASSOCIATIONS = [:category]
   end
 end

--- a/app/controllers/theblog/application_controller.rb
+++ b/app/controllers/theblog/application_controller.rb
@@ -4,7 +4,7 @@ module Theblog
     protect_from_forgery with: :exception
 
     private def menu
-      @menu ||= Page.all
+      @menu ||= Page.published
     end
     helper_method :menu
 

--- a/app/controllers/theblog/content_nodes_controller.rb
+++ b/app/controllers/theblog/content_nodes_controller.rb
@@ -3,7 +3,11 @@ module Theblog
     skip_before_action :authenticate_user!, only: [:show]
 
     def show
-      @node = ContentNode.by_parent(params[:category]).find_by!(slug: params[:slug])
+      @node = Theblog::ContentNode.published.
+        by_parent(params[:category]).
+        find_by(slug: params[:slug])
+
+      redirect_to theblog.root_path, notice: "Content not found" unless @node.present?
     end
   end
 end

--- a/app/controllers/theblog/home_controller.rb
+++ b/app/controllers/theblog/home_controller.rb
@@ -3,10 +3,10 @@ module Theblog
     skip_before_action :authenticate_user!
 
     def index
-      @node = Page.find_by(slug: 'home')
-      @node ||= Page.first
+      @node = Page.published.find_by(slug: 'home')
+      @node ||= Page.published.first
 
-      @posts = Post.all
+      @posts = Post.published.all
     end
   end
 end

--- a/app/controllers/theblog/home_controller.rb
+++ b/app/controllers/theblog/home_controller.rb
@@ -6,7 +6,7 @@ module Theblog
       @node = Page.published.find_by(slug: 'home')
       @node ||= Page.published.first
 
-      @posts = Post.published.all
+      @posts = Post.published
     end
   end
 end

--- a/app/helpers/theblog/admin_helper.rb
+++ b/app/helpers/theblog/admin_helper.rb
@@ -4,6 +4,14 @@ module Theblog
       link_to "View", path_to_item(item)
     end
 
+    def link_to_update_status(item, action)
+      link_to action.to_s.humanize, path_to_update_status(item, action), method: :put
+    end
+
+    def path_to_update_status(item, action)
+      theblog.send("admin_#{model_class(item.class)}_#{action}_path", item)
+    end
+
     def link_to_edit_item(item)
       link_to "Edit", path_to_edit_item(item)
     end
@@ -13,15 +21,15 @@ module Theblog
     end
 
     def path_to_item(item)
-      send("admin_#{model_class(item.class)}_path", item)
+      theblog.send("admin_#{model_class(item.class)}_path", item)
     end
 
     def path_to_edit_item(item)
-      send("edit_admin_#{model_class(item.class)}_path", item)
+      theblog.send("edit_admin_#{model_class(item.class)}_path", item)
     end
 
     def path_to_new_item(model)
-      send("new_admin_#{model_class(model)}_path")
+      theblog.send("new_admin_#{model_class(model)}_path")
     end
 
     def model_class(model)

--- a/app/models/theblog/content_node.rb
+++ b/app/models/theblog/content_node.rb
@@ -23,7 +23,6 @@ module Theblog
       state :drafted, initial: true
       state :published
       state :blocked
-      state :unblocked
 
       event :publish do
         transitions from: :drafted, to: :published
@@ -34,11 +33,11 @@ module Theblog
       end
 
       event :block do
-        transitions from: :any, to: :blocked
+        transitions from: [:published, :drafted], to: :blocked
       end
 
       event :unblock do
-        transitions from: :blocked, to: :unblocked
+        transitions from: :blocked, to: :drafted
       end
     end
   end

--- a/app/policies/theblog/category_policy.rb
+++ b/app/policies/theblog/category_policy.rb
@@ -1,0 +1,4 @@
+module Theblog
+  class CategoryPolicy < ContentNodePolicy
+  end
+end

--- a/app/policies/theblog/content_node_policy.rb
+++ b/app/policies/theblog/content_node_policy.rb
@@ -1,0 +1,32 @@
+module Theblog
+  class ContentNodePolicy < ApplicationPolicy
+    def create?
+      account_has_role?(user, [:editor, :moderator, :admin])
+    end
+
+    def update?
+      account_can_update_record?
+    end
+
+    def publish?
+      account_can_update_record?
+    end
+
+    def draft?
+      account_can_update_record?
+    end
+
+    def block?
+      account_has_role?(user, [:moderator, :admin])
+    end
+
+    def unblock?
+      account_has_role?(user, [:moderator, :admin])
+    end
+
+    def account_can_update_record?
+      (user == record.author && account_has_role?(user, [:editor])) ||
+        account_has_role?(user, [:moderator, :admin])
+    end
+  end
+end

--- a/app/policies/theblog/page_policy.rb
+++ b/app/policies/theblog/page_policy.rb
@@ -1,11 +1,4 @@
 module Theblog
-  class PagePolicy < ApplicationPolicy
-    def create?
-      account_has_role?(user, [:editor, :moderator, :admin])
-    end
-
-    def update?
-      user == record.author || account_has_role?(user, [:moderator, :admin])
-    end
+  class PagePolicy < ContentNodePolicy
   end
 end

--- a/app/policies/theblog/post_policy.rb
+++ b/app/policies/theblog/post_policy.rb
@@ -1,11 +1,4 @@
 module Theblog
-  class PostPolicy < ApplicationPolicy
-    def create?
-      account_has_role?(user, [:editor, :moderator, :admin])
-    end
-
-    def update?
-      user == record.author || account_has_role?(user, [:moderator, :admin])
-    end
+  class PostPolicy < ContentNodePolicy
   end
 end

--- a/app/views/theblog/admin/_manage_content_statuses.haml
+++ b/app/views/theblog/admin/_manage_content_statuses.haml
@@ -1,0 +1,3 @@
+- [:draft, :publish, :block, :unblock].each do |action|
+  - if policy(item).update? && item.send("may_#{action}?")
+    = link_to_update_status(item, action)

--- a/app/views/theblog/admin/_manage_content_statuses.haml
+++ b/app/views/theblog/admin/_manage_content_statuses.haml
@@ -1,3 +1,3 @@
 - [:draft, :publish, :block, :unblock].each do |action|
-  - if policy(item).update? && item.send("may_#{action}?")
+  - if policy(item).send("#{action}?") && item.send("may_#{action}?")
     = link_to_update_status(item, action)

--- a/app/views/theblog/admin/index.html.haml
+++ b/app/views/theblog/admin/index.html.haml
@@ -10,5 +10,6 @@
       %td
         = link_to_item(item)
         = link_to_edit_item(item) if policy(item).update?
+        = render "manage_content_statuses", item: item
 
 = link_to_new_item(model, class: 'btn btn-primary')

--- a/app/views/theblog/content_nodes/show.html.haml
+++ b/app/views/theblog/content_nodes/show.html.haml
@@ -24,5 +24,5 @@
         - if @node.is_a? Theblog::Category
           %h2.section-heading Posts:
           %ul
-            - @node.child_nodes.each do |child|
+            - @node.child_nodes.published.each do |child|
               %li= link_to_content_node(child)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,14 @@
 Theblog::Engine.routes.draw do
   namespace :admin do
-    resources :pages
-    resources :posts
-    resources :categories
+    [:pages, :posts, :categories].each do |res|
+      resources res do
+        put :draft
+        put :publish
+        put :block
+        put :unblock
+      end
+    end
+
     resources :content_statuses
     root 'dashboard#index'
   end

--- a/db/migrate/20151212093731_add_content_status_to_content_node.rb
+++ b/db/migrate/20151212093731_add_content_status_to_content_node.rb
@@ -1,0 +1,5 @@
+class AddContentStatusToContentNode < ActiveRecord::Migration
+  def change
+    add_column :theblog_content_nodes, :content_status, :string, null: false, default: "published", index: true
+  end
+end

--- a/db/migrate/20151212093731_add_content_status_to_content_node.rb
+++ b/db/migrate/20151212093731_add_content_status_to_content_node.rb
@@ -1,5 +1,5 @@
 class AddContentStatusToContentNode < ActiveRecord::Migration
   def change
-    add_column :theblog_content_nodes, :content_status, :string, null: false, default: "published", index: true
+    add_column :theblog_content_nodes, :content_status, :string, null: false, default: "", index: true
   end
 end

--- a/lib/theblog/engine.rb
+++ b/lib/theblog/engine.rb
@@ -1,5 +1,6 @@
 require 'incarnator'
 require 'pundit'
+require 'aasm'
 require 'jquery-rails'
 require 'sass'
 require 'rails-assets-font-awesome'

--- a/spec/controllers/theblog/admin/pages_controller_spec.rb
+++ b/spec/controllers/theblog/admin/pages_controller_spec.rb
@@ -5,44 +5,13 @@ module Theblog
     routes { Theblog::Engine.routes }
 
     let(:account) { FactoryGirl.create(:confirmed_account) }
-    let(:page) { FactoryGirl.create(:page) }
+    let(:content_node) { FactoryGirl.create(:page) }
+    let(:content_node_key) { :page }
 
     before { sign_in account }
 
-    describe "PATCH #update" do
-      it "raises exception if user tries to update another page" do
-        expect{ patch :update, id: page.id }.
-          to raise_error(Pundit::NotAuthorizedError)
-      end
+    it_behaves_like :admin_content_nodes_controller_update
+    it_behaves_like :admin_content_nodes_controller_create
 
-      it "updates page if user is author" do
-        page.update(author: account)
-
-        patch :update, id: page.id, page: { body: "test controller body" }
-
-        expect(response).to redirect_to(action: :show)
-        expect(page.reload.body).to eq("test controller body")
-      end
-    end
-
-    describe "POST #create" do
-      it "raises exception if user is not an editor" do
-        expect{ post :create }.
-          to raise_error(Pundit::NotAuthorizedError)
-      end
-
-      it "creates page if user has an editor role" do
-        Theblog::Role.find_by(name: :editor).accounts << account
-
-        post :create, page: { body: "test controller body", title: "title", slug: "slug" }
-
-        expect(response).to redirect_to(action: :index)
-
-        page = Theblog::Page.last
-        expect(page.body).to eq("test controller body")
-        expect(page.title).to eq("title")
-        expect(page.slug).to eq("slug")
-      end
-    end
   end
 end

--- a/spec/controllers/theblog/admin/posts_controller_spec.rb
+++ b/spec/controllers/theblog/admin/posts_controller_spec.rb
@@ -5,44 +5,13 @@ module Theblog
     routes { Theblog::Engine.routes }
 
     let(:account) { FactoryGirl.create(:confirmed_account) }
-    let(:the_post) { FactoryGirl.create(:post) }
+    let(:content_node) { FactoryGirl.create(:post) }
+    let(:content_node_key) { :post }
 
     before { sign_in account }
 
-    describe "PATCH #update" do
-      it "raises exception if user tries to update another the_post" do
-        expect{ patch :update, id: the_post.id }.
-          to raise_error(Pundit::NotAuthorizedError)
-      end
+    it_behaves_like :admin_content_nodes_controller_update
+    it_behaves_like :admin_content_nodes_controller_create
 
-      it "updates the_post if user is author" do
-        the_post.update(author: account)
-
-        patch :update, id: the_post.id, post: { body: "test controller body" }
-
-        expect(response).to redirect_to(action: :show)
-        expect(the_post.reload.body).to eq("test controller body")
-      end
-    end
-
-    describe "POST #create" do
-      it "raises exception if user is not an editor" do
-        expect{ post :create }.
-          to raise_error(Pundit::NotAuthorizedError)
-      end
-
-      it "creates the_post if user has an editor role" do
-        Theblog::Role.find_by(name: :editor).accounts << account
-
-        post :create, post: { body: "test controller body", title: "title", slug: "slug" }
-
-        expect(response).to redirect_to(action: :index)
-
-        post = Theblog::Post.last
-        expect(post.body).to eq("test controller body")
-        expect(post.title).to eq("title")
-        expect(post.slug).to eq("slug")
-      end
-    end
   end
 end

--- a/spec/controllers/theblog/content_nodes_controller_spec.rb
+++ b/spec/controllers/theblog/content_nodes_controller_spec.rb
@@ -7,8 +7,8 @@ module Theblog
     describe "GET show" do
       it "should find node by slug" do
         category_posts = double(:category_posts)
-        expect(ContentNode).to receive(:by_parent).with("test_category").and_return(category_posts)
-        expect(category_posts).to receive(:find_by!).with(slug: "test_post").and_return(double(:post))
+        expect(Theblog::ContentNode).to receive(:by_parent).with("test_category").and_return(category_posts)
+        expect(category_posts).to receive(:find_by).with(slug: "test_post").and_return(double(:post))
         get :show, category: "test_category", slug: "test_post"
         expect(response).to have_http_status(:success)
         expect(response).to render_template(:show)

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151127183614) do
+ActiveRecord::Schema.define(version: 20151212093731) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,9 +56,9 @@ ActiveRecord::Schema.define(version: 20151127183614) do
   add_index "theblog_accounts_roles", ["role_id"], name: "index_theblog_accounts_roles_on_role_id", using: :btree
 
   create_table "theblog_content_nodes", force: :cascade do |t|
-    t.string   "type",              null: false
-    t.string   "title",             null: false
-    t.string   "slug",              null: false
+    t.string   "type",                           null: false
+    t.string   "title",                          null: false
+    t.string   "slug",                           null: false
     t.text     "description"
     t.text     "body"
     t.string   "tags"
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(version: 20151127183614) do
     t.integer  "author_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "content_status",    default: "", null: false
   end
 
   add_index "theblog_content_nodes", ["author_id"], name: "index_theblog_content_nodes_on_author_id", using: :btree

--- a/spec/factories/theblog_content_nodes.rb
+++ b/spec/factories/theblog_content_nodes.rb
@@ -1,16 +1,20 @@
 FactoryGirl.define do
   factory :theblog_content_node, :class => 'Theblog::ContentNode' do
-    title "MyString"
+    sequence(:title) { |n| "Node ##{n} title" }
     sequence(:slug) { |n| "slug_#{n}" }
-    description "MyText"
+    sequence(:description) { |n| "Node ##{n} brief description" }
     body "MyText"
     tags "MyString"
+    content_status "published"
 
-    factory :category, class: 'Theblog::Category' do
-    end
-    factory :page, class: "Theblog::Page" do
-    end
-    factory :post, class: "Theblog::Post" do
+    [:category, :page, :post].each do |subclass|
+      factory subclass, class: "Theblog::#{subclass.capitalize}" do
+        [:drafted, :published, :blocked].each do |status|
+          factory "#{status}_#{subclass}" do
+            content_status status
+          end
+        end
+      end
     end
   end
 end

--- a/spec/factories/theblog_content_nodes.rb
+++ b/spec/factories/theblog_content_nodes.rb
@@ -5,7 +5,6 @@ FactoryGirl.define do
     description "MyText"
     body "MyText"
     tags "MyString"
-    content_status nil
 
     factory :category, class: 'Theblog::Category' do
     end

--- a/spec/features/admin/pages_spec.rb
+++ b/spec/features/admin/pages_spec.rb
@@ -40,7 +40,7 @@ describe 'admin pages' do
     expect(page).to have_content('Some page description')
     expect(page).to have_content('Lorem Ipsum')
 
-    all("a:contains('View')").last.click
+    all("a:contains('View')").first.click
 
     expect(page).to have_content('Page title')
     expect(page).to have_content('Some page description')

--- a/spec/features/admin/posts_spec.rb
+++ b/spec/features/admin/posts_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-describe 'admin pages' do
+describe 'admin posts' do
   let!(:account) { FactoryGirl.create(:editor) }
-  let(:node_name) { :page }
+  let(:node_name) { :post }
 
   it_behaves_like :admin_content_node
 end

--- a/spec/features/categories_spec.rb
+++ b/spec/features/categories_spec.rb
@@ -1,23 +1,28 @@
 require 'rails_helper'
 
 describe 'categories' do
-  it "should display category and posts" do
-      category = FactoryGirl.create(:category, title: "Category", slug: "category", description: "category_description")
-      FactoryGirl.create(:post, title: "Post1 Title", slug: "slug",
-                         description: "Some post1 description", body: "Lorem ipsum dolor sit amet",
-                         parent_node: category)
-      FactoryGirl.create(:post, title: "Post2 Title", slug: "slug2",
-                         description: "Some post1 description", body: "Lorem ipsum dolor sit amet",
-                         parent_node: category)
-      FactoryGirl.create(:post, title: "Post3 Title", slug: "slug3",
-                         description: "Some post1 description", body: "Lorem ipsum dolor sit amet")
+  subject { FactoryGirl.create(:category) }
 
-      visit("/theblog/category")
+  it_behaves_like :frontend_content_node
 
-      expect(page).to have_content('Category')
-      expect(page).to have_content('category_description')
-      expect(page).to have_content('Post1 Title')
-      expect(page).to have_content('Post2 Title')
-      expect(page).to have_no_content('Post3 Title')
+  it "displays category and it's published posts" do
+    own_posts = FactoryGirl.create_list(:post, 3, parent_node: subject)
+    foreign_post = FactoryGirl.create(:post)
+
+    own_non_published_posts = [:drafted, :blocked].map do |status|
+      FactoryGirl.create("#{status}_post", parent_node: subject)
+    end
+
+    visit(theblog.root_content_node_path(subject.slug))
+
+    own_posts.each do |post|
+      expect(page).to have_content(post.title)
+    end
+
+    expect(page).to have_no_content(foreign_post.title)
+
+    own_non_published_posts.each do |post|
+      expect(page).to have_no_content(post.title)
+    end
   end
 end

--- a/spec/features/pages_spec.rb
+++ b/spec/features/pages_spec.rb
@@ -1,14 +1,7 @@
 require 'rails_helper'
 
-describe "pages" do
-  it "show page" do
-    FactoryGirl.create(:page, title: "Title", slug: "slug",
-                       description: "Some page description", body: "Lorem ipsum dolor sit amet")
+describe 'pages' do
+  subject { FactoryGirl.create(:page) }
 
-    visit("/theblog/slug")
-
-    expect(page).to have_content('Title')
-    expect(page).to have_content('Some page description')
-    expect(page).to have_content('Lorem ipsum dolor sit amet')
-  end
+  it_behaves_like :frontend_content_node
 end

--- a/spec/features/posts_spec.rb
+++ b/spec/features/posts_spec.rb
@@ -1,18 +1,7 @@
 require 'rails_helper'
 
 describe 'posts' do
-  describe "show post" do
-    it "display post by slug" do
-      category = FactoryGirl.create(:category, title: "Category", slug: "category")
-      FactoryGirl.create(:post, title: "Post Title", slug: "slug",
-                         description: "Some post description", body: "Lorem ipsum dolor sit amet",
-                         parent_node: category)
+  subject { FactoryGirl.create(:post) }
 
-      visit("/theblog/category/slug")
-
-      expect(page).to have_content('Post Title')
-      expect(page).to have_content('Some post description')
-      expect(page).to have_content('Lorem ipsum dolor sit amet')
-    end
-  end
+  it_behaves_like :frontend_content_node
 end

--- a/spec/models/theblog/content_node_spec.rb
+++ b/spec/models/theblog/content_node_spec.rb
@@ -4,5 +4,11 @@ module Theblog
   RSpec.describe ContentNode, :type => :model do
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:slug) }
+
+    describe "#content_status" do
+      it "initializes with drafted" do
+        expect(subject.content_status).to eq("drafted")
+      end
+    end
   end
 end

--- a/spec/models/theblog/content_node_spec.rb
+++ b/spec/models/theblog/content_node_spec.rb
@@ -2,12 +2,25 @@ require 'rails_helper'
 
 module Theblog
   RSpec.describe ContentNode, :type => :model do
+    it { is_expected.to belong_to(:parent_node) }
+    it { is_expected.to belong_to(:author) }
+    it { is_expected.to have_many(:child_nodes) }
+
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:slug) }
+    it { is_expected.to validate_presence_of(:content_status) }
 
     describe "#content_status" do
       it "initializes with drafted" do
         expect(subject.content_status).to eq("drafted")
+      end
+
+      context "aasm" do
+        it { is_expected.to transition_from(:drafted).to(:published).on_event(:publish).on(:content_status) }
+        it { is_expected.to transition_from(:published).to(:drafted).on_event(:draft).on(:content_status) }
+        it { is_expected.to transition_from(:drafted).to(:blocked).on_event(:block).on(:content_status) }
+        it { is_expected.to transition_from(:published).to(:blocked).on_event(:block).on(:content_status) }
+        it { is_expected.to transition_from(:blocked).to(:drafted).on_event(:unblock).on(:content_status) }
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,7 +19,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+Dir["./spec/support/**/*.rb"].sort.each { |f| require f}
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require File.expand_path("../dummy/config/environment", __FILE__)
 require 'rspec/rails'
 require 'simplecov'
 require 'shoulda'
+require 'aasm/rspec'
 
 FactoryGirl.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')
 FactoryGirl.definition_file_paths << File.join(Incarnator::Engine.root, 'spec/factories')

--- a/spec/support/shared_examples/controllers/admin_content_nodes_controller.rb
+++ b/spec/support/shared_examples/controllers/admin_content_nodes_controller.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.shared_examples :admin_content_nodes_controller_update do
+  it "raises exception if user tries to update another content_node" do
+    expect{ patch :update, id: content_node.id }.
+      to raise_error(Pundit::NotAuthorizedError)
+  end
+
+  it "raises exception if user tries to update own post but is no longer editor" do
+    content_node.update(author: account)
+
+    expect{ patch :update, id: content_node.id }.
+      to raise_error(Pundit::NotAuthorizedError)
+  end
+
+  it "updates content_node if user is author and is editor" do
+    content_node.update(author: account)
+    Theblog::AccountsRole.create!(account: account, role: Theblog::Role.find_by(name: :editor))
+
+    patch :update, id: content_node.id, content_node_key => { body: "test controller body" }
+
+    expect(response).to redirect_to(action: :show)
+    expect(content_node.reload.body).to eq("test controller body")
+  end
+end
+
+RSpec.shared_examples :admin_content_nodes_controller_create do
+  it "raises exception if user is not an editor" do
+    expect{ post :create }.
+      to raise_error(Pundit::NotAuthorizedError)
+  end
+
+  it "creates post if user has an editor role" do
+    Theblog::Role.find_by(name: :editor).accounts << account
+
+    post :create, content_node_key => { body: "test controller body", title: "title", slug: "slug" }
+
+    expect(response).to redirect_to(action: :index)
+
+    loaded_node = content_node.class.order(:created_at).first
+    expect(loaded_node.body).to eq("test controller body")
+    expect(loaded_node.title).to eq("title")
+    expect(loaded_node.slug).to eq("slug")
+  end
+end

--- a/spec/support/shared_examples/features/admin_content_nodes_spec.rb
+++ b/spec/support/shared_examples/features/admin_content_nodes_spec.rb
@@ -1,0 +1,172 @@
+require 'rails_helper'
+
+RSpec.shared_examples :admin_content_node do
+  let(:node_button) { node_name.to_s.humanize }
+
+  let!(:subject_node) { FactoryGirl.create node_name, author: account }
+  let!(:blocked_node) { FactoryGirl.create "blocked_#{node_name}", author: account }
+
+  before do
+    another_account = FactoryGirl.create :confirmed_account
+    FactoryGirl.create node_name, author: another_account
+
+    login_with(account)
+
+    within('.sidebar') do
+      click_on node_button.pluralize
+    end
+  end
+
+  it "creates node" do
+    click_on "New Item"
+
+    expect(page).to have_content('New')
+
+    fill_in('Title', with: 'Node title')
+    fill_in('Slug', with: 'node_slug')
+    fill_in('Description', with: "Some node description")
+    fill_in('Body', with: "Lorem Ipsum")
+    fill_in('Tags', with: "tag1, tag2")
+
+    click_on("Create #{node_button}")
+
+    expect(page).to have_content('Item created')
+    expect(page).to have_content('Node title')
+    expect(page).to have_content('Some node description')
+    expect(page).to have_content('Lorem Ipsum')
+
+    click_on_within_node("Node title", "View")
+
+    expect(page).to have_content('Node title')
+    expect(page).to have_content('Some node description')
+    expect(page).to have_content('Lorem Ipsum')
+  end
+
+  it "updates node" do
+    expect(page).to have_content(subject_node.title)
+
+    click_on_within_node(subject_node.title, "Edit")
+
+    fill_in('Title', with: "New node name")
+    click_on("Update #{node_button}")
+
+    expect(page).to have_content('Item updated')
+    expect(page).to have_content('New node name')
+    expect(page).to have_no_content(subject_node.title)
+  end
+
+  it "drafts and publishes node" do
+    expect(page).to have_content(subject_node.title)
+
+    within node_row(subject_node) do
+      expect(page).to have_content("published")
+      expect(page).to have_link("Draft")
+      expect(page).to have_no_link("Publish")
+
+      expect(page).to have_no_link("Block")
+      expect(page).to have_no_link("Unblock")
+    end
+
+    click_on_within_node(subject_node, "Draft")
+
+    expect(page).to have_content("Item is drafted")
+
+    within node_row(subject_node) do
+      expect(page).to have_content("drafted")
+      expect(page).to have_link("Publish")
+      expect(page).to have_no_link("Draft")
+    end
+
+    click_on_within_node(subject_node, "Publish")
+
+    expect(page).to have_content("Item is published")
+
+    within node_row(subject_node) do
+      expect(page).to have_content("published")
+      expect(page).to have_link("Draft")
+      expect(page).to have_no_link("Publish")
+    end
+  end
+
+  it "moderator blocks and unblocks node" do
+    add_role(account, :moderator)
+
+    within('.sidebar') do
+      click_on node_button.pluralize
+    end
+
+    expect(page).to have_content(subject_node.title)
+
+    within node_row(subject_node) do
+      expect(page).to have_content("published")
+      expect(page).to have_link("Draft")
+      expect(page).to have_no_link("Publish")
+      expect(page).to have_link("Block")
+      expect(page).to have_no_link("Unblock")
+    end
+
+    click_on_within_node(subject_node, "Block")
+
+    expect(page).to have_content("Item is blocked")
+
+    within node_row(subject_node) do
+      expect(page).to have_content("blocked")
+      expect(page).to have_link("Unblock")
+      expect(page).to have_no_link("Block")
+      expect(page).to have_no_link("Publish")
+      expect(page).to have_no_link("Draft")
+    end
+
+    click_on_within_node(subject_node, "Unblock")
+
+    expect(page).to have_content("Item is unblocked")
+
+    within node_row(subject_node) do
+      expect(page).to have_content("drafted")
+      expect(page).to have_no_link("Unblock")
+      expect(page).to have_link("Block")
+      expect(page).to have_link("Publish")
+      expect(page).to have_no_link("Draft")
+    end
+  end
+
+  it "can neither draft or publish blocked nodes" do
+    expect(page).to have_content(blocked_node.title)
+
+    within node_row(blocked_node) do
+      expect(page).to have_content("blocked")
+      expect(page).to have_no_link("Draft")
+      expect(page).to have_no_link("Block")
+      expect(page).to have_no_link("Unblock")
+      expect(page).to have_no_link("Publish")
+    end
+  end
+
+  def add_role(account, role)
+    Theblog::Role.find_by(name: role).accounts << account
+  end
+
+  def click_on_within_node(node, link_title)
+    within node_row(node) do
+      click_on link_title
+    end
+  end
+
+  def node_row(node)
+    title = node.is_a?(String) ? node : node.title
+    "tr:contains('#{title}')"
+  end
+
+  def login_with(account)
+    visit theblog.admin_root_path
+
+    expect(page).to have_content('Log in')
+
+    fill_in('Email', with: account.email)
+    fill_in('Password', with: 'qwertyui')
+    click_on('Log in')
+
+    expect(page).to have_content('Signed in successfully')
+    expect(page).to have_content('Admin Dashboard')
+  end
+end

--- a/spec/support/shared_examples/features/content_nodes_spec.rb
+++ b/spec/support/shared_examples/features/content_nodes_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.shared_examples :frontend_content_node do
+  it "displays node" do
+    visit(theblog.root_content_node_path(subject.slug))
+
+    expect(page).to have_content(subject.title)
+    expect(page).to have_content(subject.description)
+    expect(page).to have_content(subject.body)
+  end
+
+  it "doesn't display drafted node" do
+    subject.draft!
+    visit(theblog.root_content_node_path(subject.slug))
+
+    expect(page).to have_no_content(subject.title)
+  end
+
+  it "doesn't display blocked node" do
+    subject.block!
+    visit(theblog.root_content_node_path(subject.slug))
+
+    expect(page).to have_no_content(subject.title)
+  end
+
+  it "displays node by parent" do
+    parent = FactoryGirl.create(:category)
+    subject.update(parent_node: parent)
+
+    visit(theblog.content_node_path(parent.slug, subject.slug))
+
+    expect(page).to have_content(subject.title)
+    expect(page).to have_content(subject.description)
+    expect(page).to have_content(subject.body)
+  end
+end

--- a/theblog.gemspec
+++ b/theblog.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency "simple_form", "~> 3.0"
   s.add_dependency "incarnator", "~> 0.0.1.1"
   s.add_dependency "pundit", "~> 1.0.1"
+  s.add_dependency "aasm"
 
   s.add_dependency "bootstrap-sass"
   s.add_dependency "sass-rails"


### PR DESCRIPTION
### Summary
* Add `content_status` text attribute
* Add `aasm` for content status
* Add `publish`, `draft`, `block`, `unblock` functionality
* Cover with tests
* Some tests cleanup

### Rspec
```
Finished in 3.54 seconds (files took 1.86 seconds to load)
63 examples, 0 failures
Coverage report generated for RSpec to /Users/kont/projects/drevo/theblog/coverage. 211 / 227 LOC (92.95%) covered.
```