### PR TITLE
copy theblog views generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ spec/dummy/log/*.log
 spec/dummy/tmp/
 spec/dummy/.sass-cache
 spec/dummy/config/database.yml
+spec/tmp
 **/.DS_Store
 *.gem
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,4 +18,5 @@ group :test do
   gem 'simplecov'
   gem 'capybara'
   gem 'fantaskspec'
+  gem 'generator_spec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,9 @@ GEM
     fantaskspec (0.9.9)
       rake (~> 10.0)
       rspec (~> 3.0)
+    generator_spec (0.9.3)
+      activesupport (>= 3.0.0)
+      railties (>= 3.0.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     gravtastic (3.2.6)
@@ -226,12 +229,10 @@ DEPENDENCIES
   capybara
   factory_girl_rails
   fantaskspec
+  generator_spec
   pg (~> 0.17)
   pry-rails
   rspec-rails
   shoulda
   simplecov
   theblog!
-
-BUNDLED WITH
-   1.10.6

--- a/README.markdown
+++ b/README.markdown
@@ -28,3 +28,11 @@ To add admin account run the following rake task:
 ```
 
 Follow `/blog/admin` to access the admin dashboard and `/blog` to get blog frontend.
+
+## Override views
+
+To override views run the following task:
+
+```
+  rails generate theblog:views
+```

--- a/lib/generators/theblog/views/views_generator.rb
+++ b/lib/generators/theblog/views/views_generator.rb
@@ -1,0 +1,13 @@
+class Theblog::ViewsGenerator < Rails::Generators::Base
+  source_root File.expand_path('../../../../../app/views', __FILE__)
+
+  def copy_views
+    views_pattern = File.join self.class.source_root, "**/theblog/**/*.haml"
+
+    Dir.glob(views_pattern).each do |entry|
+      unless entry =~ /admin/
+        copy_file entry, "app/views/#{entry.match(/(?<=views\/).+/)}"
+      end
+    end
+  end
+end

--- a/spec/generators/theblog/views/views_generator_spec.rb
+++ b/spec/generators/theblog/views/views_generator_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+require "generators/theblog/views/views_generator"
+
+describe Theblog::ViewsGenerator, type: :generator do
+  destination File.expand_path("../tmp", Rails.root)
+
+  it "copies engine views" do
+    prepare_destination
+    Dir.chdir(destination_root)
+
+    expect(Dir.glob("**/**")).to eq([])
+
+    run_generator
+
+    expect(Dir.glob("**/**")).to eq([
+      "app",
+      "app/views",
+      "app/views/layouts",
+      "app/views/layouts/theblog",
+      "app/views/layouts/theblog/application.html.haml",
+      "app/views/theblog",
+      "app/views/theblog/content_nodes",
+      "app/views/theblog/content_nodes/show.html.haml",
+      "app/views/theblog/home",
+      "app/views/theblog/home/index.html.haml"
+    ])
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'simplecov'
 require 'shoulda'
 require 'aasm/rspec'
 require 'fantaskspec'
+require 'generator_spec'
 
 FactoryGirl.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')
 FactoryGirl.definition_file_paths << File.join(Incarnator::Engine.root, 'spec/factories')


### PR DESCRIPTION
### Summary
Added generator that copies engine views to the application to make possible their update

### Usage

```
rails g theblog:views
      create  app/views/layouts/theblog/application.html.haml
      create  app/views/theblog/content_nodes/show.html.haml
      create  app/views/theblog/home/index.html.haml
```